### PR TITLE
Initial work to parrallelize net requests, adding overrides for locations 

### DIFF
--- a/main.go
+++ b/main.go
@@ -875,6 +875,7 @@ func main() {
 
 	noGui := len(ops.NoGUI) == 1 && ops.NoGUI[0]
 	dm := MakeGameDefManager()
+	dm.ApplyUserOverrides()
 
 	if noGui {
 		CliMain(ops, dm)


### PR DESCRIPTION
This creates a worker pool for performing network requests. Right now I am defaulting to 4 workers but I want to make that user customizable. 

If the file `OsCacheDir` + user_overrides.json is present, we will patch our default save definition data with user input. This will allow for custom apps.

On MacOS, this looks like `/Users/daviddesimone/Library/Caches/SteamCustomCloudUpload/user_overrides.json`

