### PR TITLE
[#53] [Core] Default to Sync Operation; Allow "BiSync" as an option

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -172,7 +172,7 @@ func (cm *CloudManager) ListFiles(ops *CloudOperationOptions, localPath string) 
 }
 
 func (cm *CloudManager) PerformSyncOperation(storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
-	fmt.Println("Performing BiSync....")
+	fmt.Println("Performing Sync Operation....")
 	os.MkdirAll(localPath, os.ModePerm)
 	exists, err := cm.DoesRemoteDirExist(storage, remotePath)
 	if err != nil {

--- a/cloud.go
+++ b/cloud.go
@@ -171,14 +171,9 @@ func (cm *CloudManager) ListFiles(ops *CloudOperationOptions, localPath string) 
 	return arr, nil
 }
 
-func (cm *CloudManager) BisyncDir(storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
+func (cm *CloudManager) PerformSyncOperation(storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
 	fmt.Println("Performing BiSync....")
 	os.MkdirAll(localPath, os.ModePerm)
-	// _, err := os.Stat(localPath)
-	// if err != nil {
-	// 	return "", err
-	// }
-
 	exists, err := cm.DoesRemoteDirExist(storage, remotePath)
 	if err != nil {
 		return "", err
@@ -189,6 +184,49 @@ func (cm *CloudManager) BisyncDir(storage Storage, ops *CloudOperationOptions, l
 			return "", err
 		}
 	}
+
+	cloudperfs := GetCurrentCloudPerfsOrDefault()
+	if cloudperfs.UseSync {
+		return cm.syncDir(storage, ops, localPath, remotePath)
+	} else {
+		return cm.bisyncDir(storage, ops, localPath, remotePath)
+	}
+}
+
+func (cm *CloudManager) syncDir(storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
+	// We can't pass an empty string as a flag to the rclone command, but we
+	// can pass the same flag multiple times. We use this as a hack to enable
+	// conditional commands with a varargs function. There is likely a better way to
+	// do this, but this should be generally low cost.
+	defaultFlag := "--use-json-log"
+
+	verboseString := defaultFlag
+	if ops.Verbose {
+		verboseString = "-v"
+	}
+
+	dryRunString := defaultFlag
+	if ops.DryRun {
+		dryRunString = "--dry-run"
+	}
+
+	include := defaultFlag
+	if ops.Include != "" {
+		include = fmt.Sprintf("--include=%v", ops.Include)
+	}
+
+	path := fmt.Sprintf("%v:%v", storage.GetName(), remotePath)
+	fmt.Println("Running Command ", getCloudApp(), defaultFlag, verboseString, dryRunString, include, "sync", localPath, path)
+	cmd := makeCommand(getCloudApp(), defaultFlag, verboseString, dryRunString, include, "sync", localPath, path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+func (cm *CloudManager) bisyncDir(storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
 
 	// We can't pass an empty string as a flag to the rclone command, but we
 	// can pass the same flag multiple times. We use this as a hack to enable

--- a/cloud.go
+++ b/cloud.go
@@ -186,13 +186,14 @@ func (cm *CloudManager) PerformSyncOperation(storage Storage, ops *CloudOperatio
 	}
 
 	cloudperfs := GetCurrentCloudPerfsOrDefault()
-	if cloudperfs.UseSync {
-		return cm.syncDir(storage, ops, localPath, remotePath)
-	} else {
+	if cloudperfs.UseBiSync {
 		return cm.bisyncDir(storage, ops, localPath, remotePath)
+	} else {
+		return cm.syncDir(storage, ops, localPath, remotePath)
 	}
 }
 
+// @TODO support cancellation
 func (cm *CloudManager) syncDir(storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
 	// We can't pass an empty string as a flag to the rclone command, but we
 	// can pass the same flag multiple times. We use this as a hack to enable
@@ -256,6 +257,7 @@ func (cm *CloudManager) bisyncDir(storage Storage, ops *CloudOperationOptions, l
 	if err != nil {
 		exiterr := err.(*exec.ExitError)
 		if exiterr.ExitCode() == 2 {
+			// @TODO - in this case, I want to explain sync vs bisync to the user and let them choose
 			fmt.Println("Need to run resync")
 			fmt.Println("Running Command ", getCloudApp(), defaultFlag, verboseString, dryRunString, include, "--resync", "bisync", localPath, path)
 			cmd := makeCommand(getCloudApp(), defaultFlag, verboseString, dryRunString, include, "bisync", "--resync", localPath, path)

--- a/cloud_perfs.go
+++ b/cloud_perfs.go
@@ -76,7 +76,17 @@ func writeCloudPerfs(cloudperfs *CloudPerfs) error {
 		return err
 	}
 
-	return os.WriteFile(path, data, os.ModePerm)
+	err = os.WriteFile(path, data, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	cm := MakeCloudManager()
+	storage := GetCurrentStorageProvider()
+	ops := GetDefaultCloudOptions()
+	go cm.PerformSyncOperation(storage, ops, path, ToplevelCloudFolder+"user_settings/")
+
+	return nil
 }
 
 func GetCurrentCloudPerfs() (*CloudPerfs, error) {

--- a/cloud_perfs.go
+++ b/cloud_perfs.go
@@ -15,7 +15,7 @@ const NEXT = 4
 type CloudPerfs struct {
 	Cloud         int  `json:"cloud"`
 	PerformDryRun bool `json:"performDryRun"`
-	UseSync       bool `json:"useStdSync"`
+	UseBiSync     bool `json:"useBiSync"`
 }
 
 func getCloudPerfDir() (string, error) {

--- a/cloud_perfs.go
+++ b/cloud_perfs.go
@@ -15,6 +15,7 @@ const NEXT = 4
 type CloudPerfs struct {
 	Cloud         int  `json:"cloud"`
 	PerformDryRun bool `json:"performDryRun"`
+	UseSync       bool `json:"useStdSync"`
 }
 
 func getCloudPerfDir() (string, error) {

--- a/gamedef_manager.go
+++ b/gamedef_manager.go
@@ -315,6 +315,6 @@ func ApplyCloudUserOverride(cm *CloudManager, userOverride string) error {
 
 	path := filepath.Dir(userOverride)
 	ops := GetDefaultCloudOptions()
-	_, err := cm.BisyncDir(storage, ops, path, ToplevelCloudFolder+"user_settings/")
+	_, err := cm.PerformSyncOperation(storage, ops, path, ToplevelCloudFolder+"user_settings/")
 	return err
 }

--- a/gui.go
+++ b/gui.go
@@ -433,8 +433,8 @@ func executeTemplate() (string, error) {
 
 	htmlWriter.Flush()
 	result := b.String()
-	js := fmt.Sprintf("<script>%v</script>", jsContent)
-	css := fmt.Sprintf("<style>%v</style>", cssContent)
+	js := fmt.Sprintf("<script>%v</script>", string(jsContent))
+	css := fmt.Sprintf("<style>%v</style>", string(cssContent))
 	syncgamejs := fmt.Sprintf("\n<script>%v</script>\n", string(syncgamejsbytes))
 	settingsjs := fmt.Sprintf("<script>%v</script>\n", string(settingsjsbytes))
 	finalResult := css + result + js + syncgamejs + settingsjs

--- a/gui.go
+++ b/gui.go
@@ -19,19 +19,8 @@ import (
 	"github.com/webview/webview"
 )
 
-// @TODO merge everything to the embedded html synthetic fs
-
 //go:embed html
 var html embed.FS
-
-//go:embed html/index.html
-var htmlMain embed.FS
-
-//go:embed html/style.css
-var cssContent string
-
-//go:embed html/main.js
-var jsContent string
 
 type SaveFile struct {
 	Filename   string
@@ -416,7 +405,7 @@ func executeTemplate() (string, error) {
 	var b bytes.Buffer
 	htmlWriter := bufio.NewWriterSize(&b, 2*1024*1024)
 
-	templ := template.Must(template.ParseFS(htmlMain, "html/index.html"))
+	templ := template.Must(template.ParseFS(html, "html/index.html"))
 	err := templ.Execute(htmlWriter, input)
 	if err != nil {
 		return "", err
@@ -428,6 +417,16 @@ func executeTemplate() (string, error) {
 	}
 
 	settingsjsbytes, err := fs.ReadFile(html, "html/settings.js")
+	if err != nil {
+		return "", err
+	}
+
+	jsContent, err := fs.ReadFile(html, "html/main.js")
+	if err != nil {
+		return "", err
+	}
+
+	cssContent, err := fs.ReadFile(html, "html/style.css")
 	if err != nil {
 		return "", err
 	}

--- a/html/index.html
+++ b/html/index.html
@@ -120,11 +120,11 @@
     </div>
     <div class="settings-switch-cont">
       <label class="switch switch-float">
-        <input id="settings-use-sync" type="checkbox" onclick="onUseSyncToggle(this)">
+        <input id="settings-use-sync" type="checkbox" onclick="onUseBiSyncToggle(this)">
         <span class="slider round"></span>
       </label>
       <div class="setting-text">
-        <p>Use a standard Sync instead of a BiSync.</p>
+        <p>Use a Bi-Directional Sync instead of a standard Sync.</p>
       </div>
     </div>
     <div class="clearfix">

--- a/html/index.html
+++ b/html/index.html
@@ -7,7 +7,7 @@
     <ul class="topnav">
         <li><div class="activeButton" onclick="openAddGamesMenu()" style="width:auto;">Add Games</div></li>
         <li><div onclick="onSetCloudClicked(this)">Select Cloud</div></li>
-        <li><div onclick="onSyncSettingsClicked(this)">Sync Settings</div></li>
+        <li><div onclick="onSyncSettingsClicked(this)">Settings</div></li>
         <div class="search-container">
               <input type="text" placeholder="Search.." name="search" onchange="onChangeSearch(this)" onkeypress="onChangeSearch(this)" onpaste = "onChangeSearch(this)" oninput = "onChangeSearch(this)">
           </div>  

--- a/html/index.html
+++ b/html/index.html
@@ -109,11 +109,22 @@
     <hr>
     <div class="settings-switch-cont">
       <label class="switch switch-float">
-        <input id="settings-dry-run" type="checkbox" onclick="onSettingsToggle(this)">
+        <input id="settings-dry-run" type="checkbox" onclick="onDryRunToggle(this)">
         <span class="slider round"></span>
       </label>
       <div class="setting-text">
         <p>Perform a Dry Run prior to sync.</p>
+      </div>
+    </div>
+    <div class="clearfix">
+    </div>
+    <div class="settings-switch-cont">
+      <label class="switch switch-float">
+        <input id="settings-use-sync" type="checkbox" onclick="onUseSyncToggle(this)">
+        <span class="slider round"></span>
+      </label>
+      <div class="setting-text">
+        <p>Use a standard Sync instead of a BiSync.</p>
       </div>
     </div>
     <div class="clearfix">

--- a/html/settings.js
+++ b/html/settings.js
@@ -16,7 +16,7 @@ async function onSettingsModalOpen() {
     dryRunSwitch.checked = currentSettings.performDryRun;
 
     const syncSwitch = document.getElementById('settings-use-sync');
-    syncSwitch.checked = currentSettings.useStdSync;
+    syncSwitch.checked = currentSettings.useBiSync;
 }
 
 async function onDryRunToggle(element) {
@@ -28,11 +28,11 @@ async function onDryRunToggle(element) {
     await commitCloudPerfs(JSON.stringify(currentSettings));
 }
 
-async function onUseSyncToggle(element) {
+async function onUseBiSyncToggle(element) {
     const syncSwitch = document.getElementById('settings-use-sync');
     const currentSettingsString = await getCloudPerfs();
     const currentSettings = JSON.parse(currentSettingsString);
 
-    currentSettings.useStdSync = syncSwitch.checked;
+    currentSettings.useBiSync = syncSwitch.checked;
     await commitCloudPerfs(JSON.stringify(currentSettings));
 }

--- a/html/settings.js
+++ b/html/settings.js
@@ -14,13 +14,25 @@ async function onSettingsModalOpen() {
 
     const dryRunSwitch = document.getElementById('settings-dry-run');
     dryRunSwitch.checked = currentSettings.performDryRun;
+
+    const syncSwitch = document.getElementById('settings-use-sync');
+    syncSwitch.checked = currentSettings.useStdSync;
 }
 
-async function onSettingsToggle(element) {
+async function onDryRunToggle(element) {
     const dryRunSwitch = document.getElementById('settings-dry-run');
     const currentSettingsString = await getCloudPerfs();
     const currentSettings = JSON.parse(currentSettingsString);
 
     currentSettings.performDryRun = dryRunSwitch.checked;
+    await commitCloudPerfs(JSON.stringify(currentSettings));
+}
+
+async function onUseSyncToggle(element) {
+    const syncSwitch = document.getElementById('settings-use-sync');
+    const currentSettingsString = await getCloudPerfs();
+    const currentSettings = JSON.parse(currentSettingsString);
+
+    currentSettings.useStdSync = syncSwitch.checked;
     await commitCloudPerfs(JSON.stringify(currentSettings));
 }

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func CliMain(cm *CloudManager, ops *Options, dm GameDefManager, channels *Channe
 
 			syncops.Include = syncpath.Include
 
-			result, err := cm.BisyncDir(storage, syncops, syncpath.Path, remotePath)
+			result, err := cm.PerformSyncOperation(storage, syncops, syncpath.Path, remotePath)
 			if err != nil {
 				fmt.Println(err)
 				continue


### PR DESCRIPTION
https://github.com/DavidDeSimone/OpenCloudSaves/issues/53

Early feedback has been that several users have been confused by our default "bi-sync" functionality. The issue is that many users have two separate sets of save data that they are trying to merge, and this is not congruent with a bisync flow. We expose an option in Settings to opt back into a bisync flow. 