### PR TITLE
[#52] Fixing bug where any direct path to a steam play game would not properly resolve.

### DIFF
--- a/gamedef_manager.go
+++ b/gamedef_manager.go
@@ -119,13 +119,14 @@ func (d *GameDef) GetSyncpaths() ([]Datapath, error) {
 				linuxPath = strings.Replace(linuxPath, "$XDG_CONFIG_HOME", homedir, 1)
 			}
 
-			if strings.Contains(datapath.Path, "/pfx/") {
+			if strings.HasSuffix(datapath.Path, "pfx") || strings.HasSuffix(datapath.Path, "pfx/") {
 				if len(d.WinPath) == 0 {
 					fmt.Println("Unable to resolve " + datapath.Path)
 					continue
 				}
 
 				winpath := d.WinPath[0].Path
+				winpath = strings.Replace(winpath, "C:\\", "", 1)
 				winpath = strings.Replace(winpath, "%APPDATA%", "users/steamuser/AppData/Roaming/", 1)
 				winpath = strings.Replace(winpath, "%LOCALAPPDATA%", "users/steamuser/AppData/Local/", 1)
 				winpath = strings.Replace(winpath, "%USERPROFILE%", "users/steamuser/", 1)


### PR DESCRIPTION
https://github.com/DavidDeSimone/OpenCloudSaves/issues/52

To resolve the fake c_drive that steam play uses, we have a special case in our path resolution logic. The issue was that logic looked for any instance of "pfx" in the string instead of looking that the string ended in "pfx". This PR updates this logic to handle that case, and also handle cases where the game is installed in C:\ for our win path. 