### PR TITLE
Improve Error Reporting

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -283,8 +283,7 @@ func (cm *CloudManager) syncDir(storage Storage, ops *CloudOperationOptions, loc
 
 	err := cmd.Run()
 	if err != nil {
-		fmt.Println(stderr.String())
-		return "", err
+		return "", fmt.Errorf(stderr.String())
 	}
 
 	// Rclone reports the information we want to display to the user

--- a/html/style.css
+++ b/html/style.css
@@ -123,13 +123,12 @@ li div:hover:not(.activeButton) {
     padding: 8px 28px;
     margin-top: 4px;
     background-color: #f44336;
-} /* Red */ 
+} 
 .danger:hover {background: #da190b;}
 
 body {font-family: Arial, Helvetica, sans-serif;}
 * {box-sizing: border-box;}
 
-/* Full-width input fields */
 input[type=text], input[type=password] {
   width: 100%;
   padding: 15px;
@@ -147,13 +146,11 @@ input[type=text], input[type=password] {
   text-align: center;
 }
 
-/* Add a background color when the inputs get focus */
 input[type=text]:focus, input[type=password]:focus {
   background-color: #ddd;
   outline: none;
 }
 
-/* Set a style for all buttons */
 .contentbutton {
   background-color: #04AA6D;
   color: white;
@@ -192,7 +189,6 @@ input[type=text]:focus, input[type=password]:focus {
   text-align: center;
   margin-top: 50px;
   margin-bottom: 20px;
-  /* margin: auto; */
   border: 1px;
 }
 
@@ -220,13 +216,11 @@ input[type=text]:focus, input[type=password]:focus {
   
   }
 
-/* Extra styles for the cancel button */
 .cancelbtn {
   padding: 14px 20px;
   background-color: #f44336;
 }
 
-/* Float cancel and signup buttons and add an equal width */
 .cancelbtn, .signupbtn {
   float: left;
   width: 50%;
@@ -240,54 +234,50 @@ input[type=text]:focus, input[type=password]:focus {
   opacity: 30%;
 }
 
-/* Add padding to container elements */
 .container {
   padding: 16px;
 }
 
-/* The Modal (background) */
 .modal {
-  display: none; /* Hidden by default */
-  position: fixed; /* Stay in place */
-  z-index: 1; /* Sit on top */
+  display: none; 
+  position: fixed; 
+  z-index: 1; 
   left: 0;
   top: 0;
-  width: 100%; /* Full width */
-  height: 100%; /* Full height */
-  overflow: auto; /* Enable scroll if needed */
+  width: 100%; 
+  height: 100%; 
+  overflow: auto; 
   background-color: #474e5d;
   padding-top: 50px;
 }
 
-/* Modal Content/Box */
 .modal-content {
   background-color: #fefefe;
-  margin: 5% auto 15% auto; /* 5% from the top, 15% from the bottom and centered */
+  margin: 5% auto 15% auto; 
   border: 1px solid #888;
-  width: 80%; /* Could be more or less, depending on screen size */
+  width: 80%; 
 }
 
 .bisync-modal {
-  display: none; /* Hidden by default */
-  position: fixed; /* Stay in place */
-  z-index: 1; /* Sit on top */
+  display: none; 
+  position: fixed; 
+  z-index: 1; 
   left: 0;
   top: 0;
-  width: 100%; /* Full width */
-  height: 100%; /* Full height */
-  overflow: auto; /* Enable scroll if needed */
+  width: 100%; 
+  height: 100%; 
+  overflow: auto; 
   background-color: #474e5d;
   padding-top: 50px;
 }
 
-/* Modal Content/Box */
+
 .bisync-modal-content {
   background-color: #fefefe;
-  margin: 5% auto 15% auto; /* 5% from the top, 15% from the bottom and centered */
+  margin: 5% auto 15% auto; 
   border: 1px solid #888;
   font-family: monospace;
-  /* font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; */
-  width: 95%; /* Could be more or less, depending on screen size */
+  width: 95%; 
 }
 
 .bisync-line-cont {
@@ -316,24 +306,24 @@ input[type=text]:focus, input[type=password]:focus {
 }
 
 .settings-modal {
-  display: none; /* Hidden by default */
-  position: fixed; /* Stay in place */
-  z-index: 1; /* Sit on top */
+  display: none; 
+  position: fixed; 
+  z-index: 1; 
   left: 0;
   top: 0;
-  width: 100%; /* Full width */
-  height: 100%; /* Full height */
-  overflow: auto; /* Enable scroll if needed */
+  width: 100%; 
+  height: 100%; 
+  overflow: auto; 
   background-color: #474e5d;
   padding-top: 50px;
 }
 
-/* Modal Content/Box */
+
 .settings-modal-content {
   background-color: #fefefe;
-  margin: 5% auto 15% auto; /* 5% from the top, 15% from the bottom and centered */
+  margin: 5% auto 15% auto; 
   border: 1px solid #888;
-  width: 95%; /* Could be more or less, depending on screen size */
+  width: 95%; 
 }
 
 .settings-title {
@@ -420,7 +410,6 @@ input:checked + .slider:before {
   transform: translateX(26px);
 }
 
-/* Rounded sliders */
 .slider.round {
   border-radius: 34px;
 }
@@ -429,13 +418,11 @@ input:checked + .slider:before {
   border-radius: 50%;
 }
 
-/* Style the horizontal ruler */
 hr {
   border: 1px solid #f1f1f1;
   margin-bottom: 25px;
 }
  
-/* The Close Button (x) */
 .close {
   position: absolute;
   right: 35px;
@@ -451,7 +438,6 @@ hr {
   cursor: pointer;
 }
 
-/* Clear floats */
 .clearfix::after {
   content: "";
   clear: both;
@@ -518,8 +504,6 @@ hr {
   }
 }
 
-
-/* Change styles for cancel button and signup button on extra small screens */
 @media screen and (max-width: 300px) {
   .cancelbtn, .signupbtn {
      width: 100%;


### PR DESCRIPTION
Prior to this PR, we were doing a poor job of surfacing errors to the user base. This resulted in several reports of users saying they were left hanging on the "sync" screen. I think this was likely the result of a lack of communication to the user - they likely timed out their network requests, but we didn't provide the user that information. 

I also performed some code cleanup around how we generate our rclone command - we now construct an argument slice for our argument values.