### PR TITLE
Hook up proper cancellation flow

### DIFF
--- a/core/box_cloud.go
+++ b/core/box_cloud.go
@@ -1,6 +1,9 @@
 package core
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 type BoxStorage struct {
 }
@@ -9,8 +12,8 @@ func (gs *BoxStorage) GetName() string {
 	return "opencloudsave-box"
 }
 
-func (gs *BoxStorage) GetCreationCommand() *exec.Cmd {
-	return makeCommand(getCloudApp(), "config", "create", gs.GetName(), "box")
+func (gs *BoxStorage) GetCreationCommand(ctx context.Context) *exec.Cmd {
+	return makeCommand(ctx, getCloudApp(), "config", "create", gs.GetName(), "box")
 }
 
 var boxStorage *BoxStorage

--- a/core/cloud.go
+++ b/core/cloud.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -234,7 +235,7 @@ func (cm *CloudManager) ObscurePassword(password string) (string, error) {
 	return output.String(), nil
 }
 
-func (cm *CloudManager) PerformSyncOperation(storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
+func (cm *CloudManager) PerformSyncOperation(ctx context.Context, storage Storage, ops *CloudOperationOptions, localPath string, remotePath string) (string, error) {
 	InfoLogger.Println("Performing Sync Operation")
 	os.MkdirAll(localPath, os.ModePerm)
 	exists, err := cm.DoesRemoteDirExist(storage, remotePath)

--- a/core/cloud_perfs.go
+++ b/core/cloud_perfs.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -85,7 +86,7 @@ func writeCloudPerfs(cloudperfs *CloudPerfs) error {
 	cm := MakeCloudManager()
 	storage := GetCurrentStorageProvider()
 	ops := GetDefaultCloudOptions()
-	go cm.PerformSyncOperation(storage, ops, path, ToplevelCloudFolder+"user_settings/")
+	go cm.PerformSyncOperation(context.Background(), storage, ops, path, ToplevelCloudFolder+"user_settings/")
 
 	return nil
 }

--- a/core/core.go
+++ b/core/core.go
@@ -31,15 +31,23 @@ type Message struct {
 }
 
 type ChannelProvider struct {
-	Logs chan Message
+	Logs   chan Message
+	Cancel context.CancelFunc
 }
 
 const APP_NAME = "OpenCloudSave"
 
 func MakeDefaultChannelProvider() *ChannelProvider {
 	return &ChannelProvider{
-		Logs: make(chan Message, 100),
+		Logs:   make(chan Message, 100),
+		Cancel: nil,
 	}
+}
+
+func MakeChannelProviderWithCancelFunction(cancelFn context.CancelFunc) *ChannelProvider {
+	provider := MakeDefaultChannelProvider()
+	provider.Cancel = cancelFn
+	return provider
 }
 
 func GetCurrentStorageProvider() Storage {

--- a/core/core.go
+++ b/core/core.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -35,6 +36,12 @@ type ChannelProvider struct {
 
 const APP_NAME = "OpenCloudSave"
 
+func MakeDefaultChannelProvider() *ChannelProvider {
+	return &ChannelProvider{
+		Logs: make(chan Message, 100),
+	}
+}
+
 func GetCurrentStorageProvider() Storage {
 	storage, err := GetCurrentCloudStorage()
 	if err != nil {
@@ -50,7 +57,7 @@ func LogMessage(logs chan Message, format string, msg ...any) {
 	}
 }
 
-func RequestMainOperation(cm *CloudManager, ops *Options, dm GameDefManager, channels *ChannelProvider) {
+func RequestMainOperation(ctx context.Context, cm *CloudManager, ops *Options, dm GameDefManager, channels *ChannelProvider) {
 	logs := channels.Logs
 
 	if len(ops.PrintGameDefs) > 0 {
@@ -128,7 +135,7 @@ func RequestMainOperation(cm *CloudManager, ops *Options, dm GameDefManager, cha
 			syncops.CustomFlags = gamedef.CustomFlags
 			syncops.Include = syncpath.Include
 
-			result, err := cm.PerformSyncOperation(storage, syncops, syncpath.Path, remotePath)
+			result, err := cm.PerformSyncOperation(ctx, storage, syncops, syncpath.Path, remotePath)
 			if err != nil {
 				ErrorLogger.Println(err)
 				logs <- Message{

--- a/core/dropbox_cloud.go
+++ b/core/dropbox_cloud.go
@@ -1,6 +1,9 @@
 package core
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 type DropBoxStorage struct {
 }
@@ -9,8 +12,8 @@ func (gs *DropBoxStorage) GetName() string {
 	return "opencloudsave-dropbox"
 }
 
-func (gs *DropBoxStorage) GetCreationCommand() *exec.Cmd {
-	return makeCommand(getCloudApp(), "config", "create", gs.GetName(), "dropbox")
+func (gs *DropBoxStorage) GetCreationCommand(ctx context.Context) *exec.Cmd {
+	return makeCommand(ctx, getCloudApp(), "config", "create", gs.GetName(), "dropbox")
 }
 
 var dropboxStorage *DropBoxStorage

--- a/core/ftp_cloud.go
+++ b/core/ftp_cloud.go
@@ -1,6 +1,9 @@
 package core
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 type FtpStorage struct {
 	Host     string `json:"host"`
@@ -13,7 +16,7 @@ func (ftpfs *FtpStorage) GetName() string {
 	return "opencloudsave-ftp"
 }
 
-func (ftpfs *FtpStorage) GetCreationCommand() *exec.Cmd {
+func (ftpfs *FtpStorage) GetCreationCommand(ctx context.Context) *exec.Cmd {
 	args := []string{"config", "create", ftpfs.GetName(), "ftp"}
 	if ftpfs.Host != "" {
 		args = append(args, "host="+ftpfs.Host)
@@ -28,15 +31,15 @@ func (ftpfs *FtpStorage) GetCreationCommand() *exec.Cmd {
 		args = append(args, "pass="+ftpfs.Password)
 	}
 
-	return makeCommand(getCloudApp(), args...)
+	return makeCommand(ctx, getCloudApp(), args...)
 }
 
 var ftpDrive *FtpStorage
 
-func DeleteFtpDriveStorage() error {
+func DeleteFtpDriveStorage(ctx context.Context) error {
 	storage := &FtpStorage{}
 	cm := MakeCloudManager()
-	return cm.DeleteCloudEntry(storage)
+	return cm.DeleteCloudEntry(ctx, storage)
 }
 
 func SetFtpDriveStorage(ftp *FtpStorage) {

--- a/core/gamedef_manager.go
+++ b/core/gamedef_manager.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -317,6 +318,6 @@ func ApplyCloudUserOverride(cm *CloudManager, userOverride string) error {
 
 	path := filepath.Dir(userOverride)
 	ops := GetDefaultCloudOptions()
-	_, err := cm.PerformSyncOperation(storage, ops, path, ToplevelCloudFolder+"user_settings/")
+	_, err := cm.PerformSyncOperation(context.Background(), storage, ops, path, ToplevelCloudFolder+"user_settings/")
 	return err
 }

--- a/core/google_cloud.go
+++ b/core/google_cloud.go
@@ -1,6 +1,9 @@
 package core
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 type GoogleStorage struct {
 }
@@ -9,8 +12,8 @@ func (gs *GoogleStorage) GetName() string {
 	return "opencloudsave-googledrive"
 }
 
-func (gs *GoogleStorage) GetCreationCommand() *exec.Cmd {
-	return makeCommand(getCloudApp(), "config", "create", gs.GetName(), "drive", "scope=drive.file")
+func (gs *GoogleStorage) GetCreationCommand(ctx context.Context) *exec.Cmd {
+	return makeCommand(ctx, getCloudApp(), "config", "create", gs.GetName(), "drive", "scope=drive.file")
 }
 
 var gdrive *GoogleStorage

--- a/core/next_cloud.go
+++ b/core/next_cloud.go
@@ -1,6 +1,9 @@
 package core
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 type NextCloudStorage struct {
 	Url          string `json:"url"`
@@ -13,7 +16,7 @@ func (gs *NextCloudStorage) GetName() string {
 	return "opencloudsave-nextcloud"
 }
 
-func (gs *NextCloudStorage) GetCreationCommand() *exec.Cmd {
+func (gs *NextCloudStorage) GetCreationCommand(ctx context.Context) *exec.Cmd {
 	args := []string{"config", "create", gs.GetName(), "webdav", "vendor=nextcloud"}
 	if gs.Url != "" {
 		args = append(args, "url="+gs.Url)
@@ -28,15 +31,15 @@ func (gs *NextCloudStorage) GetCreationCommand() *exec.Cmd {
 		args = append(args, "bearer_token="+gs.Bearer_token)
 	}
 
-	return makeCommand(getCloudApp(), args...)
+	return makeCommand(ctx, getCloudApp(), args...)
 }
 
 var nextCloudStorage *NextCloudStorage
 
-func DeleteNextCloudStorage() error {
+func DeleteNextCloudStorage(ctx context.Context) error {
 	storage := &NextCloudStorage{}
 	cm := MakeCloudManager()
-	return cm.DeleteCloudEntry(storage)
+	return cm.DeleteCloudEntry(ctx, storage)
 }
 
 func SetNextCloudStorage(ns *NextCloudStorage) {

--- a/core/onedrive_cloud.go
+++ b/core/onedrive_cloud.go
@@ -1,6 +1,9 @@
 package core
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 type OneDriveStorage struct {
 }
@@ -9,8 +12,8 @@ func (gs *OneDriveStorage) GetName() string {
 	return "opencloudsave-onedrive"
 }
 
-func (gs *OneDriveStorage) GetCreationCommand() *exec.Cmd {
-	return makeCommand(getCloudApp(), "config", "create", gs.GetName(), "onedrive", "drive_type=personal", "access_scopes=Files.ReadWrite,offline_access")
+func (gs *OneDriveStorage) GetCreationCommand(ctx context.Context) *exec.Cmd {
+	return makeCommand(ctx, getCloudApp(), "config", "create", gs.GetName(), "onedrive", "drive_type=personal", "access_scopes=Files.ReadWrite,offline_access")
 }
 
 var onedrive *OneDriveStorage

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -365,7 +365,7 @@ func cancelPendingSync(gameName string) {
 	if ok && channels.Cancel != nil {
 		channels.Cancel()
 	}
-	removeGamedefByKey(gameName)
+	cleanupPendingChannel(gameName)
 }
 
 func deleteCurrentNextCloudSettings() {

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -54,6 +54,7 @@ func consoleLog(s string) {
 	fmt.Println(s)
 }
 
+// @TODO roll this into a class that manages the channel providers
 var chanelMutex sync.Mutex
 var channelMap map[string]*core.ChannelProvider = make(map[string]*core.ChannelProvider)
 

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -359,6 +359,7 @@ func commitNextCloudSettings(jsonInput string) error {
 }
 
 func cancelPendingSync(gameName string) {
+	core.InfoLogger.Println("Cancel sync of " + gameName)
 	chanelMutex.Lock()
 	channels, ok := channelMap[gameName]
 	chanelMutex.Unlock()
@@ -366,6 +367,8 @@ func cancelPendingSync(gameName string) {
 	if ok && channels.Cancel != nil {
 		channels.Cancel()
 	}
+
+	removeGamedefByKey(gameName)
 }
 
 func deleteCurrentNextCloudSettings() {

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 			log.Fatal("Attempting to sync cloud data with no cloud provider set. Please set a cloud provider via --set-cloud <CLOUD_PROVIDER>")
 		}
 
-		err = cm.CreateDriveIfNotExists(storage)
+		err = cm.CreateDriveIfNotExists(context.Background(), storage)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"runtime"
@@ -88,11 +89,9 @@ func main() {
 	dm.CommitUserOverrides()
 
 	if noGui {
-		channels := &core.ChannelProvider{
-			Logs: make(chan core.Message, 100),
-		}
+		channels := core.MakeDefaultChannelProvider()
 		go core.ConsoleLogger(channels.Logs)
-		core.RequestMainOperation(cm, ops, dm, channels)
+		core.RequestMainOperation(context.Background(), cm, ops, dm, channels)
 	} else {
 		gui.GuiMain(ops, dm)
 	}


### PR DESCRIPTION
Improvement for situations described in https://github.com/DavidDeSimone/OpenCloudSaves/issues/85 (though I am not calling it a "fix" for that issue)

Now the user will be shown a cancellation screen when hitting the X or Cancel buttons in both the multisync and single sync screens. This will look like:

<img width="803" alt="Screenshot 2023-03-13 at 9 12 46 PM" src="https://user-images.githubusercontent.com/7245174/224891319-58106275-697b-4154-9f3e-785388af7394.png">

