### PR TITLE
Improve UX if cloud selection fails. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/sqweek/dialog v0.0.0-20220809060634-e981b270ebbf
 	github.com/webview/webview v0.0.0-20230110200822-73aee3dae745
 	golang.org/x/sys v0.3.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (
 	github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -699,10 +699,13 @@ func GuiMain(ops *core.Options, dm core.GameDefManager) {
 		}
 	}
 
+	defer (func() {
+		// This may not work on macOS due to a combination of issues
+		// https://github.com/webview/webview/issues/669
+		// https://github.com/webview/webview/issues/372
+		cancelPendingCloudSelection()
+	})()
+
 	w.Run()
 
-	// This may not work on macOS due to a combination of issues
-	// https://github.com/webview/webview/issues/669
-	// https://github.com/webview/webview/issues/372
-	cancelPendingCloudSelection()
 }

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -700,4 +700,9 @@ func GuiMain(ops *core.Options, dm core.GameDefManager) {
 	}
 
 	w.Run()
+
+	// This may not work on macOS due to a combination of issues
+	// https://github.com/webview/webview/issues/669
+	// https://github.com/webview/webview/issues/372
+	cancelPendingCloudSelection()
 }

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -241,9 +241,13 @@ func load(w webview.WebView, path string) error {
 
 var pendingCloudChannelProvider *core.ChannelProvider
 
-func cancelPendingCloudSelection() {
+func cancelPendingCloudSelection(block bool) {
 	if pendingCloudChannelProvider != nil {
 		pendingCloudChannelProvider.Cancel()
+		if block {
+			msg := <-pendingCloudChannelProvider.Logs
+			fmt.Println(msg)
+		}
 		pendingCloudChannelProvider = nil
 	}
 }
@@ -496,7 +500,9 @@ func bindFunctions(w webview.WebView) {
 	w.Bind("cancelPendingSync", cancelPendingSync)
 	w.Bind("getMultisyncSelectedGames", getMultisyncSelectedGames)
 	w.Bind("commitMultisyncSelectGames", commitMultisyncSelectGames)
-	w.Bind("cancelPendingCloudSelection", cancelPendingCloudSelection)
+	w.Bind("cancelPendingCloudSelection", func() {
+		cancelPendingCloudSelection(false)
+	})
 	w.Bind("isCloudSelectionComplete", isCloudSelectionComplete)
 }
 
@@ -703,7 +709,7 @@ func GuiMain(ops *core.Options, dm core.GameDefManager) {
 		// This may not work on macOS due to a combination of issues
 		// https://github.com/webview/webview/issues/669
 		// https://github.com/webview/webview/issues/372
-		cancelPendingCloudSelection()
+		cancelPendingCloudSelection(true)
 	})()
 
 	w.Run()

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -22,6 +22,9 @@ import (
 	"github.com/webview/webview"
 )
 
+// @TODO We don't need to do JS-level polling, instead we can dispatch a
+// callback using w.Dispatch / w.Eval
+
 //go:embed html
 var html embed.FS
 
@@ -236,7 +239,41 @@ func load(w webview.WebView, path string) error {
 	return nil
 }
 
-func commitCloudService(ctx context.Context, service int) error {
+var pendingCloudChannelProvider *core.ChannelProvider
+
+func cancelPendingCloudSelection() {
+	if pendingCloudChannelProvider != nil {
+		pendingCloudChannelProvider.Cancel()
+		pendingCloudChannelProvider = nil
+	}
+}
+
+func isCloudSelectionComplete() (bool, error) {
+	if pendingCloudChannelProvider != nil {
+		select {
+		case msg := <-pendingCloudChannelProvider.Logs:
+			if msg.Finished || msg.Err != nil {
+				pendingCloudChannelProvider = nil
+				return true, msg.Err
+			}
+		default:
+			// no-op
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func createDrive(ctx context.Context, cm *core.CloudManager, storage core.Storage, chnl *core.ChannelProvider) {
+	err := cm.CreateDriveIfNotExists(ctx, storage)
+	chnl.Logs <- core.Message{
+		Err:      err,
+		Finished: true,
+	}
+}
+
+func commitCloudService(service int) error {
 	cloudperfs := core.GetCurrentCloudPerfsOrDefault()
 	cloudperfs.Cloud = service
 	err := core.CommitCloudPerfs(cloudperfs)
@@ -249,8 +286,12 @@ func commitCloudService(ctx context.Context, service int) error {
 		return err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	pendingCloudChannelProvider = core.MakeChannelProviderWithCancelFunction(cancel)
+
 	cm := core.MakeCloudManager()
-	return cm.CreateDriveIfNotExists(ctx, storage)
+	go createDrive(ctx, cm, storage, pendingCloudChannelProvider)
+	return nil
 }
 
 func getCloudService() (int, error) {
@@ -455,6 +496,8 @@ func bindFunctions(w webview.WebView) {
 	w.Bind("cancelPendingSync", cancelPendingSync)
 	w.Bind("getMultisyncSelectedGames", getMultisyncSelectedGames)
 	w.Bind("commitMultisyncSelectGames", commitMultisyncSelectGames)
+	w.Bind("cancelPendingCloudSelection", cancelPendingCloudSelection)
+	w.Bind("isCloudSelectionComplete", isCloudSelectionComplete)
 }
 
 func DirSize(path string) (int64, error) {

--- a/gui/html/multisync.js
+++ b/gui/html/multisync.js
@@ -48,10 +48,10 @@ async function resetSuccessAndFailureMarkers() {
     }
 }
 
-async function confirmCancellation() {
+async function multisyncConfirmationCancellation() {
     makeConfirmationPopup({
-        title: `Are you sure you want to cancel perform a sync of multiple games?`,
-        subtitle: `Hitting confirm will cancel your pending sync operation.`,
+        title: `Are you sure you want to cancel this operation?`,
+        subtitle: `If this was not a dry-run, your sync may be partially complete.`,
         onConfirm: async () => {
             if (MultiSyncState.gameToSync !== '') {
                 await cancelPendingSync(MultiSyncState.gameToSync);
@@ -67,7 +67,7 @@ async function confirmCancellation() {
 
 async function onCloseMultisync(element) {
     if (MultiSyncState.hasActiveSyncOperation) {
-        await confirmCancellation();
+        await multisyncConfirmationCancellation();
         return;
     }
 

--- a/gui/html/selectcloud.js
+++ b/gui/html/selectcloud.js
@@ -1,17 +1,53 @@
+const CloudSelectionState = {
+    pendingCloudInitialization: false,
+};
+
+
 async function closeSelectCloud(element) {
+    CloudSelectionState.pendingCloudInitialization = false;
     refresh();
 }
 
+// @TODO if you close the window, this will not kill the pending rclone
+// process, and subsequent syncs will fail. 
 async function cloudSelected(cloudService) {
-    await log("Selected " + cloudService);
+    if (CloudSelectionState.pendingCloudInitialization) {
+        await cancelPendingCloudSelection();
+    }
+
+    const closeModal = document.getElementById("closemodal");
+    closeModal.style.display = 'none';
+
+    log("Selected " + cloudService);
+    await setCloud(cloudService, "(Pending)");
+    CloudSelectionState.pendingCloudInitialization = true;
     await commitCloudService(cloudService);
-    refresh();
+
+    const timer = 250;
+    const poll = async () => {
+        const result = await isCloudSelectionComplete()
+                        .catch(e => {
+                            log(`Error setting up cloud ${e}`);
+                        });
+        if (result) {
+            refresh();
+        } else {
+            setTimeout(poll, timer);
+
+        }
+    };
+    setTimeout(poll, timer);
 }
+
 
 async function setCurrentCloud() {
+    const service = await getCloudService();
+    await setCloud(service);
+}
+
+async function setCloud(service, postfix = "") {
     const currentCloudEl = document.getElementById("currentcloudcont");
     const closeModal = document.getElementById("closemodal");
-    const service = await getCloudService();
     const prefix = "Current Cloud Storage: ";
     let value = "";
 
@@ -45,7 +81,7 @@ async function setCurrentCloud() {
     }
 
     if (value !== "") {
-        currentCloudEl.innerText = prefix + value;
+        currentCloudEl.innerText = prefix + value + postfix;
     }
 }
 

--- a/gui/html/selectcloud.js
+++ b/gui/html/selectcloud.js
@@ -18,8 +18,7 @@ async function cloudSelected(cloudService) {
     const closeModal = document.getElementById("closemodal");
     closeModal.style.display = 'none';
 
-    log("Selected " + cloudService);
-    await setCloud(cloudService, "(Pending)");
+    await setCloud(cloudService, " (Pending)");
     CloudSelectionState.pendingCloudInitialization = true;
     await commitCloudService(cloudService);
 

--- a/gui/html/syncgame.js
+++ b/gui/html/syncgame.js
@@ -184,8 +184,8 @@ async function setupSyncModal(gameName) {
 
 async function confirmCancellation() {
     makeConfirmationPopup({
-        title: `Are you sure you want to cancel sync'ing ${CurrentSyncState.gameToSync}?`,
-        subtitle: `Hitting confirm will cancel your pending sync operation.`,
+        title: `Are you sure you want to cancel this operation?`,
+        subtitle: `If this was not a dry-run, your sync may be partially complete.`,
         onConfirm: async () => {
             await cancelPendingSync(CurrentSyncState.gameToSync);
             CurrentSyncState.gameToSync = null;


### PR DESCRIPTION
Fixes the issue of getting "locked" while selecting a cloud https://github.com/DavidDeSimone/OpenCloudSaves/issues/62 on Linux/Windows. 

This won't fix getting locked from Google Cloud if too many users have signed up recently, and unfortunately due to issues with our macOS Webview bindings, our solution does not work with macOS. I have an idea for a platform specific workaround, but that will be a separate PR. The majority of users are on Windows/Linux, so this should be a much better experience for the majority of users. 