### PR TITLE
Fixing up messy platform-specific path logic.

### DIFF
--- a/core/cloud.go
+++ b/core/cloud.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"opencloudsave/platform"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 )
 
@@ -15,13 +14,6 @@ const ToplevelCloudFolder = "opencloudsaves/"
 
 // Used for debugging
 const printCommands = true
-
-// This is a real hack, but we fallback to $PATH if we can't
-// find rclone locally in linux. This is really only for the
-// flatpak - we control what version of rclone will be on $PATH
-// within the flatpak
-var checkedLinuxPath = false
-var relativeLinuxPath = true
 
 type Storage interface {
 	GetName() string
@@ -50,31 +42,7 @@ type CloudFile struct {
 }
 
 func getCloudApp() string {
-	switch runtime.GOOS {
-	case "linux":
-		if !checkedLinuxPath {
-			_, err := os.Stat("./bin/rclone")
-			if err != nil {
-				relativeLinuxPath = false
-			}
-			checkedLinuxPath = true
-		}
-
-		if relativeLinuxPath {
-			return "./bin/rclone"
-		} else {
-			return "rclone"
-		}
-
-	case "windows":
-		return "./bin/rclone.exe"
-	case "darwin":
-		return GetMacOsPath()
-	default:
-		log.Fatal("Unsupported Platform")
-	}
-
-	return "Unsupported Platform"
+	return platform.GetPath()
 }
 
 func makeCommand(ctx context.Context, cmd_string string, arg ...string) *exec.Cmd {
@@ -83,7 +51,7 @@ func makeCommand(ctx context.Context, cmd_string string, arg ...string) *exec.Cm
 	}
 
 	cmd := exec.CommandContext(ctx, cmd_string, arg...)
-	StripWindow(cmd)
+	platform.StripWindow(cmd)
 	return cmd
 }
 

--- a/core/winux_stubs.go
+++ b/core/winux_stubs.go
@@ -1,7 +1,0 @@
-//go:build windows || linux
-
-package core
-
-func GetMacOsPath() string {
-	return ""
-}

--- a/main.go
+++ b/main.go
@@ -9,13 +9,14 @@ import (
 
 	"opencloudsave/core"
 	"opencloudsave/gui"
+	"opencloudsave/platform"
 
 	"github.com/jessevdk/go-flags"
 )
 
 func main() {
 	if runtime.GOOS == "windows" {
-		core.SetupWindowsConsole()
+		platform.SetupWindowsConsole()
 	}
 
 	ops := &core.Options{}

--- a/platform/crossplatform_utils.go
+++ b/platform/crossplatform_utils.go
@@ -1,4 +1,4 @@
-package core
+package platform
 
 import (
 	"fmt"

--- a/platform/debug_windows_console.go
+++ b/platform/debug_windows_console.go
@@ -1,6 +1,6 @@
 //go:build windows && debug
 
-package core
+package platform
 
 import (
 	"fmt"

--- a/platform/platform_ext_linux.go
+++ b/platform/platform_ext_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package platform
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+)
+
+var checkedLinuxPath = false
+var relativeLinuxPath = false
+
+func GetPath() string {
+	if !checkedLinuxPath {
+		_, err := os.Stat("./bin/rclone")
+		if err != nil {
+			relativeLinuxPath = false
+		}
+		checkedLinuxPath = true
+	}
+
+	if relativeLinuxPath {
+		return "./bin/rclone"
+	} else {
+		return "rclone"
+	}
+}

--- a/platform/platform_ext_linux.go
+++ b/platform/platform_ext_linux.go
@@ -5,7 +5,6 @@ package platform
 import (
 	_ "embed"
 	"os"
-	"path/filepath"
 )
 
 var checkedLinuxPath = false

--- a/platform/platform_ext_macos.go
+++ b/platform/platform_ext_macos.go
@@ -1,6 +1,6 @@
 //go:build darwin
 
-package core
+package platform
 
 import (
 	_ "embed"
@@ -11,7 +11,7 @@ import (
 var checkedPath = false
 var useMacRelativePath = false
 
-func GetMacOsPath() string {
+func GetPath() string {
 	if !checkedPath {
 		_, err := os.Stat("./bin/rclone")
 		if err == nil {

--- a/platform/platform_ext_windows.go
+++ b/platform/platform_ext_windows.go
@@ -3,16 +3,8 @@
 package platform
 
 import (
-	"encoding/json"
-	"fmt"
-	"log"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"syscall"
-
-	"github.com/andygrunwald/vdf"
-	"golang.org/x/sys/windows/registry"
 )
 
 func GetPath() string {
@@ -23,66 +15,66 @@ func StripWindow(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 }
 
-func (d *GameDef) GetInstallLocationFromSteamId() string {
-	key, err := registry.OpenKey(registry.CURRENT_USER, `SOFTWARE\Valve\Steam`, registry.QUERY_VALUE)
-	if err != nil {
-		log.Panic(err)
-	}
-	defer key.Close()
+// func (d *core.GameDef) GetInstallLocationFromSteamId() string {
+// 	key, err := registry.OpenKey(registry.CURRENT_USER, `SOFTWARE\Valve\Steam`, registry.QUERY_VALUE)
+// 	if err != nil {
+// 		log.Panic(err)
+// 	}
+// 	defer key.Close()
 
-	steamPath, _, err := key.GetStringValue("SteamPath")
-	if err != nil {
-		log.Panic(err)
-	}
+// 	steamPath, _, err := key.GetStringValue("SteamPath")
+// 	if err != nil {
+// 		log.Panic(err)
+// 	}
 
-	libraryFoldersStr, err := os.Open(filepath.Join(steamPath, "steamapps", "libraryfolders.vdf"))
-	if err != nil {
-		log.Panic(err)
-	}
+// 	libraryFoldersStr, err := os.Open(filepath.Join(steamPath, "steamapps", "libraryfolders.vdf"))
+// 	if err != nil {
+// 		log.Panic(err)
+// 	}
 
-	parser := vdf.NewParser(libraryFoldersStr)
-	libraryFoldersMap, err := parser.Parse()
-	if err != nil {
-		log.Panic(err)
-	}
+// 	parser := vdf.NewParser(libraryFoldersStr)
+// 	libraryFoldersMap, err := parser.Parse()
+// 	if err != nil {
+// 		log.Panic(err)
+// 	}
 
-	jsonStr, err := json.Marshal(libraryFoldersMap)
-	if err != nil {
-		log.Panic(err)
-	}
+// 	jsonStr, err := json.Marshal(libraryFoldersMap)
+// 	if err != nil {
+// 		log.Panic(err)
+// 	}
 
-	libraryFolders := LibraryFolders{}
-	json.Unmarshal(jsonStr, &libraryFolders)
+// 	libraryFolders := LibraryFolders{}
+// 	json.Unmarshal(jsonStr, &libraryFolders)
 
-	for _, libraryFolder := range libraryFolders.LibraryFolders {
-		for steamId := range libraryFolder.Apps {
-			if steamId == d.SteamId {
-				steamAppsDir := filepath.Join(libraryFolder.Path, "steamapps")
+// 	for _, libraryFolder := range libraryFolders.LibraryFolders {
+// 		for steamId := range libraryFolder.Apps {
+// 			if steamId == d.SteamId {
+// 				steamAppsDir := filepath.Join(libraryFolder.Path, "steamapps")
 
-				appManifestStr, err := os.Open(filepath.Join(steamAppsDir, fmt.Sprintf("appmanifest_%s.acf", d.SteamId)))
-				if err != nil {
-					log.Panic(err)
-				}
+// 				appManifestStr, err := os.Open(filepath.Join(steamAppsDir, fmt.Sprintf("appmanifest_%s.acf", d.SteamId)))
+// 				if err != nil {
+// 					log.Panic(err)
+// 				}
 
-				parser := vdf.NewParser(appManifestStr)
-				appManifestMap, err := parser.Parse()
-				if err != nil {
-					log.Panic(err)
-				}
+// 				parser := vdf.NewParser(appManifestStr)
+// 				appManifestMap, err := parser.Parse()
+// 				if err != nil {
+// 					log.Panic(err)
+// 				}
 
-				jsonStr, err := json.Marshal(appManifestMap)
-				if err != nil {
-					log.Panic(err)
-				}
+// 				jsonStr, err := json.Marshal(appManifestMap)
+// 				if err != nil {
+// 					log.Panic(err)
+// 				}
 
-				appManifest := AppManifest{}
-				json.Unmarshal(jsonStr, &appManifest)
+// 				appManifest := AppManifest{}
+// 				json.Unmarshal(jsonStr, &appManifest)
 
-				result := filepath.Join(steamAppsDir, "common", appManifest.AppState.InstallDir)
-				return result
-			}
-		}
-	}
+// 				result := filepath.Join(steamAppsDir, "common", appManifest.AppState.InstallDir)
+// 				return result
+// 			}
+// 		}
+// 	}
 
-	return ""
-}
+// 	return ""
+// }

--- a/platform/platform_ext_windows.go
+++ b/platform/platform_ext_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package core
+package platform
 
 import (
 	"encoding/json"
@@ -14,6 +14,10 @@ import (
 	"github.com/andygrunwald/vdf"
 	"golang.org/x/sys/windows/registry"
 )
+
+func GetPath() string {
+	return "./bin/rclone.exe"
+}
 
 func StripWindow(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}

--- a/platform/release_windows_console.go
+++ b/platform/release_windows_console.go
@@ -1,6 +1,6 @@
 //go:build windows && !debug
 
-package core
+package platform
 
 func SetupWindowsConsole() {
 

--- a/platform/unix_stubs.go
+++ b/platform/unix_stubs.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package core
+package platform
 
 import "os/exec"
 

--- a/platform/winux_stubs.go
+++ b/platform/winux_stubs.go
@@ -1,0 +1,3 @@
+//go:build windows || linux
+
+package platform


### PR DESCRIPTION
This moves all platform specific code into a platform module, and gives a uniform interface for the logic that resolves the `rclone` path. 