### PR TITLE
Add The Sims 4

### DIFF
--- a/core/gamedef_map.json
+++ b/core/gamedef_map.json
@@ -699,5 +699,21 @@
             }
         ],
         "darwin_path": []
+    },
+    "The Sims 4": {
+        "display_name": "The Sims 4",
+        "win_path": [
+            {
+                "path": "%USERPROFILE%\\Documents\\Electronic Arts\\The Sims 4\\saves\\",
+                "inc": ""
+            }
+        ],
+        "linux_path": [
+            {
+                "path": "%STEAM%/steamapps/compatdata/1222670/pfx/",
+                "inc": ""
+            }
+        ],
+        "darwin_path": []
     }
 }


### PR DESCRIPTION
Adds `The Sims 4` to the list of games that can be cloud saved. It hasn't been tested since I haven't gotten cross compilation working but it should work.